### PR TITLE
fix: fix contract audit issues

### DIFF
--- a/contracts/TransakMulticallExecuter.sol
+++ b/contracts/TransakMulticallExecuter.sol
@@ -1,29 +1,40 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+// Importing required OpenZeppelin contracts
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
 
+/**
+ * @title TransakMulticallExecuter
+ * @dev This contract allows to execute multiple calls in a single transaction and handles ERC721 and ERC1155 tokens.
+ */
 contract TransakMulticallExecuter is
-    OwnableUpgradeable,
+    Ownable2StepUpgradeable,
     ReentrancyGuardUpgradeable,
     IERC721Receiver,
     IERC1155Receiver
 {
+
+   // Interface IDs for ERC165, ERC721 and ERC1155
     bytes4 public constant ERC165_INTERFACE_ID = 0x01ffc9a7;
     bytes4 public constant ERC721_TOKENRECEIVER_INTERFACE_ID = 0x150b7a02;
     bytes4 public constant ERC1155_TOKENRECEIVER_INTERFACE_ID = 0x4e2312e0;
 
+    // Events emitted
     event MulticallExecuted(address[] targets, bytes[] data);
     event NativeTokenReceived(address, uint256);
 
+    // Custom error to be thrown when a call fails
     error CallFailed(address _target, bytes _data);
+    error CallFailedWithReason(address _target, bytes _data, string _reason);
 
-    // @dev This function is called to initialize the contract
+    /**
+     * @dev Initializes the contract by setting up ownership and reentrancy guard
+     */
     function initialize() public initializer {
         __Ownable_init();
         __ReentrancyGuard_init();
@@ -38,6 +49,7 @@ contract TransakMulticallExecuter is
      * @dev This function allows the contract to call multiple external contracts in one transaction.
      * @param targets The addresses of the contracts to call.
      * @param data The calldata to pass to each contract.
+     * @param value The amount of Ether to send to each contract.
      * @return results The results of each call.
      */
     function multiCall(
@@ -45,17 +57,16 @@ contract TransakMulticallExecuter is
         bytes[] calldata data,
         uint256[] calldata value
     ) external payable onlyOwner nonReentrant returns (bytes[] memory) {
-        require(
-            reduce(value) <= msg.value,
-            "msg.value should be greater than sum of value[]"
-        );
-
+        require(reduce(value) <= msg.value,"msg.value should be greater than sum of value[]");
         require(targets.length != 0, "target length is 0");
         require(targets.length == data.length, "target length != data length");
+        require(targets.length == value.length, "target length != value length");
+
 
         bytes[] memory results = new bytes[](data.length);
 
         for (uint256 i; i < targets.length; i++) {
+            require(targets[i].code.length > 0 || data[i].length == 0, "target account is not a valid contract.if EOA data must be empty");
             (bool success, bytes memory result) = targets[i].call{
                 value: value[i]
             }(data[i]);
@@ -64,9 +75,11 @@ contract TransakMulticallExecuter is
                 if (result.length == 0) {
                     revert CallFailed(targets[i], data[i]);
                 }
+                
                 assembly {
-                    revert(add(result, 32), mload(result))
+                       result := add(result, 0x04)
                 }
+                revert CallFailedWithReason(targets[i], data[i],abi.decode(result,(string)));
             }
             results[i] = result;
         }
@@ -94,7 +107,7 @@ contract TransakMulticallExecuter is
      * which means it does not read from or write to the blockchain state.
      *
      * @param interfaceId The ID of the interface to check.
-     * @return A boolean indicating whether the contract supports the given interface.
+     * @return _ A boolean indicating whether the contract supports the given interface.
      */
     function supportsInterface(
         bytes4 interfaceId
@@ -139,7 +152,7 @@ contract TransakMulticallExecuter is
         uint256,
         bytes calldata
     ) external pure override returns (bytes4) {
-        return this.onERC1155Received.selector;
+        return IERC1155Receiver.onERC1155Received.selector;
     }
 
     /**
@@ -158,7 +171,15 @@ contract TransakMulticallExecuter is
         uint256[] calldata,
         bytes calldata
     ) external pure override returns (bytes4) {
-        return this.onERC1155BatchReceived.selector;
+        return IERC1155Receiver.onERC1155BatchReceived.selector;
+    }
+
+    /**
+     * @dev This function allows the contract owner to withdraw all Ether from the contract.
+     */
+    function withdrawEther() external onlyOwner {
+        // Transfer the contract's Ether balance to the owner's address
+        payable(msg.sender).transfer(address(this).balance);
     }
 
     /**

--- a/contracts/TransakMulticallExecuter.sol
+++ b/contracts/TransakMulticallExecuter.sol
@@ -36,7 +36,7 @@ contract TransakMulticallExecuter is
      * @dev Initializes the contract by setting up ownership and reentrancy guard
      */
     function initialize() public initializer {
-        __Ownable_init();
+        __Ownable2Step_init();
         __ReentrancyGuard_init();
     }
 
@@ -151,7 +151,7 @@ contract TransakMulticallExecuter is
         uint256,
         uint256,
         bytes calldata
-    ) external pure override returns (bytes4) {
+    ) external pure returns (bytes4) {
         return IERC1155Receiver.onERC1155Received.selector;
     }
 
@@ -170,7 +170,7 @@ contract TransakMulticallExecuter is
         uint256[] calldata,
         uint256[] calldata,
         bytes calldata
-    ) external pure override returns (bytes4) {
+    ) external pure returns (bytes4) {
         return IERC1155Receiver.onERC1155BatchReceived.selector;
     }
 


### PR DESCRIPTION
This PR fixes following  issues

**3.1 Excess Ether Received by the Contract Is Locked**
Added withdrawEther function to withdraw ether
```
 /**
     * @dev This function allows the contract owner to withdraw all Ether from the contract.
     */
    function withdrawEther() external onlyOwner {
        // Transfer the contract's Ether balance to the owner's address
        payable(msg.sender).transfer(address(this).balance);
    }

```

**3.2 Missing Input Validation for value.length in multiCall()**
Added require statement to check length of value to be equal to length of targets
```
require(targets.length == value.length, "target length != value length");

```

**3.3 The Revert Reason of multiCall() Should Include the Target Address That Led to the Failure**
Added a new error type with reason which reverts with the reason
```
assembly {
                       result := add(result, 0x04)
                }
                revert CallFailedWithReason(targets[i], data[i],abi.decode(result,(string)));
```

**3.4 The multiCall() Function Does Not Check if the Targets Contain Executable Code**
Added condition to check contract is valid and in case of EOA the check is diasabled
```
require(targets[i].code.length > 0 || data[i].length == 0, "target account is not a valid contract.if EOA data must be empty");
```

**3.5 Use the Ownable2StepUpgradeable Library in Place of OwnableUpgradeable**
Replaced OwnableUpgradeable to Ownable2StepUpgradeable
```
import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
import "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";

/**
 * @title TransakMulticallExecuter
 * @dev This contract allows to execute multiple calls in a single transaction and handles ERC721 and ERC1155 tokens.
 */
contract TransakMulticallExecuter is
    Ownable2StepUpgradeable,
    ReentrancyGuardUpgradeable,
    IERC721Receiver,
    IERC1155Receiver
{
```

**3.6 Unnecessary override and Inconsistency Between Code and Documentation in onERC1155Received() and onERC1155BatchReceived()**

Removed override modifier and Changed  Functions to return selector from the Interface

```

   function onERC1155Received(
        address,
        address,
        uint256,
        uint256,
        bytes calldata
    ) external pure returns (bytes4) {
        return IERC1155Receiver.onERC1155Received.selector;
    }

    function onERC1155BatchReceived(
        address,
        address,
        uint256[] calldata,
        uint256[] calldata,
        bytes calldata
    ) external pure returns (bytes4) {
        return IERC1155Receiver.onERC1155BatchReceived.selector;
    }


```

**3.7 Incomplete NatSpec Comments**

Updated Comments in multicall for missing parameters and Updated the Natspec in the whole contract

```
 * @dev This function allows the contract to call multiple external contracts in one transaction.
     * @param targets The addresses of the contracts to call.
     * @param data The calldata to pass to each contract.
     * @param value The amount of Ether to send to each contract.
     * @return results The results of each call.
     */
    function multiCall(
        address[] calldata targets,
        bytes[] calldata data,
        uint256[] calldata value
    ) 

```